### PR TITLE
Add required boxen module version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ heroku::plugin { 'accounts':
 
 ## Required Puppet Modules
 
-* `boxen`
+* `boxen '3.3.4'`
 
 ## Development
 


### PR DESCRIPTION
Fix the common error of using an older Boxen module version which results in issue #5
