### PR TITLE
Fish Compatibility

### DIFF
--- a/files/heroku.fish
+++ b/files/heroku.fish
@@ -1,0 +1,3 @@
+# Add Heroku bins to PATH
+
+set -gx PATH "$BOXEN_HOME/heroku/bin" $PATH

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,9 +20,10 @@ class heroku {
   }
 
   boxen::env_script { 'heroku-fish':
-    priority  => 'lower',
-    source    => 'puppet:///modules/heroku/heroku.fish',
-    extension => 'fish',
+    priority   => 'lower',
+    source     => 'puppet:///modules/heroku/heroku.fish',
+    scriptname => 'heroku',
+    extension  => 'fish',
   }
 
   boxen::env_script { 'heroku':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,8 +20,9 @@ class heroku {
   }
 
   boxen::env_script { 'heroku-fish':
-    priority => 'lower',
-    source   => 'puppet:///modules/heroku/heroku.fish',
+    priority  => 'lower',
+    source    => 'puppet:///modules/heroku/heroku.fish',
+    extension => 'fish',
   }
 
   boxen::env_script { 'heroku':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,11 @@ class heroku {
       ensure => absent ;
   }
 
+  boxen::env_script { 'heroku-fish':
+    priority => 'lower',
+    source   => 'puppet:///modules/heroku/heroku.fish',
+  }
+
   boxen::env_script { 'heroku':
     priority => 'lower',
     source   => 'puppet:///modules/heroku/heroku.sh',


### PR DESCRIPTION
Adds a Fish version of the env script. 

Relies on boxen/puppet-boxen#138 (for the `extension` argument to `env_script`).
